### PR TITLE
Add data pipeline utilities and scripts

### DIFF
--- a/gsc_pull.py
+++ b/gsc_pull.py
@@ -1,0 +1,175 @@
+"""Pipeline that pulls Search Console performance data and stores it in Supabase."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import quote
+
+from util_gsc_oauth import GSCAuthenticator
+from util_supabase import SupabaseWriter
+
+logger = logging.getLogger(__name__)
+
+SEARCH_ANALYTICS_ENDPOINT = "https://searchconsole.googleapis.com/webmasters/v3/sites/{site_url}/searchAnalytics/query"
+
+
+def _parse_properties(raw: str) -> List[str]:
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _parse_date(value: Optional[str], default: date) -> str:
+    if not value:
+        return default.isoformat()
+    value = value.strip()
+    if value.lower() == "yesterday":
+        return (date.today() - timedelta(days=1)).isoformat()
+    if value.lower() == "today":
+        return date.today().isoformat()
+    return date.fromisoformat(value).isoformat()
+
+
+def _coerce_float(value: Any, fallback: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _build_row(
+    site_url: str,
+    dimensions: List[str],
+    row: Dict[str, Any],
+    requested_at: datetime,
+) -> Dict[str, Any]:
+    keys = row.get("keys", [])
+    metrics = {
+        "clicks": row.get("clicks", 0.0),
+        "impressions": row.get("impressions", 0.0),
+        "ctr": row.get("ctr", 0.0),
+        "position": row.get("position", 0.0),
+    }
+    dimension_values = dict(zip(dimensions, keys))
+    payload = {
+        "property_url": site_url,
+        "requested_at": requested_at.isoformat(),
+        **dimension_values,
+        **metrics,
+    }
+    return payload
+
+
+def fetch_search_console_rows(
+    authenticator: GSCAuthenticator,
+    *,
+    site_url: str,
+    start_date: str,
+    end_date: str,
+    dimensions: List[str],
+    row_limit: int,
+    dimension_filters: Optional[List[Dict[str, Any]]] = None,
+    search_type: str = "web",
+) -> List[Dict[str, Any]]:
+    url = SEARCH_ANALYTICS_ENDPOINT.format(site_url=quote(site_url, safe=""))
+    body: Dict[str, Any] = {
+        "startDate": start_date,
+        "endDate": end_date,
+        "dimensions": dimensions,
+        "rowLimit": row_limit,
+        "type": search_type,
+    }
+    if dimension_filters:
+        body["dimensionFilterGroups"] = dimension_filters
+
+    logger.info(
+        "Requesting GSC Search Analytics for %s (%s -> %s) dimensions=%s",
+        site_url,
+        start_date,
+        end_date,
+        dimensions,
+    )
+    response = authenticator.authenticated_request("POST", url, json=body)
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Failed to fetch GSC data for {site_url}: {response.status_code} {response.text}"
+        )
+    payload = response.json()
+    rows = payload.get("rows", [])
+    logger.info("Received %s rows for %s", len(rows), site_url)
+    return rows
+
+
+def filter_rows(rows: Iterable[Dict[str, Any]], *, min_impressions: float) -> List[Dict[str, Any]]:
+    filtered = []
+    for row in rows:
+        impressions = _coerce_float(row.get("impressions"), 0.0)
+        if impressions < min_impressions:
+            continue
+        filtered.append(row)
+    return filtered
+
+
+def run() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+
+    properties_raw = os.getenv("GSC_PROPERTIES")
+    if not properties_raw:
+        raise RuntimeError("GSC_PROPERTIES environment variable is required")
+    properties = _parse_properties(properties_raw)
+
+    lookback_days = int(os.getenv("GSC_LOOKBACK_DAYS", "3"))
+    end_date = _parse_date(os.getenv("GSC_END_DATE"), date.today())
+    start_date = _parse_date(
+        os.getenv("GSC_START_DATE"),
+        date.fromisoformat(end_date) - timedelta(days=lookback_days),
+    )
+
+    dimensions_env = os.getenv("GSC_DIMENSIONS", "date,query,page")
+    dimensions = [item.strip() for item in dimensions_env.split(",") if item.strip()]
+
+    row_limit = int(os.getenv("GSC_ROW_LIMIT", "25000"))
+    min_impressions = float(os.getenv("GSC_MIN_IMPRESSIONS", "0"))
+    search_type = os.getenv("GSC_SEARCH_TYPE", "web")
+
+    dimension_filters_json = os.getenv("GSC_DIMENSION_FILTERS")
+    dimension_filters = json.loads(dimension_filters_json) if dimension_filters_json else None
+
+    supabase_table = os.getenv("GSC_SUPABASE_TABLE", "gsc_search_analytics")
+    on_conflict = os.getenv("GSC_SUPABASE_CONFLICT", "property_url,date,query,page")
+
+    authenticator = GSCAuthenticator()
+    supabase = SupabaseWriter()
+
+    requested_at = datetime.utcnow()
+    for site_url in properties:
+        rows = fetch_search_console_rows(
+            authenticator,
+            site_url=site_url,
+            start_date=start_date,
+            end_date=end_date,
+            dimensions=dimensions,
+            row_limit=row_limit,
+            dimension_filters=dimension_filters,
+            search_type=search_type,
+        )
+        if min_impressions > 0:
+            rows = filter_rows(rows, min_impressions=min_impressions)
+        payload = [_build_row(site_url, dimensions, row, requested_at) for row in rows]
+        if not payload:
+            logger.info("No rows to upsert for %s", site_url)
+            continue
+        supabase.upsert_rows(supabase_table, payload, on_conflict=on_conflict)
+
+
+def main() -> None:
+    try:
+        run()
+    except Exception:  # pragma: no cover - runtime guard
+        logger.exception("GSC pipeline failed")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/gsc_queries_top.py
+++ b/gsc_queries_top.py
@@ -1,0 +1,109 @@
+"""Pipeline extracting the top Search Console queries for each property."""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List
+
+from gsc_pull import _parse_date, _parse_properties, fetch_search_console_rows
+from util_gsc_oauth import GSCAuthenticator
+from util_supabase import SupabaseWriter
+
+logger = logging.getLogger(__name__)
+
+
+def _build_payload(
+    site_url: str,
+    dimensions: List[str],
+    row: Dict[str, Any],
+    *,
+    period_start: str,
+    period_end: str,
+    requested_at: datetime,
+    rank: int,
+) -> Dict[str, Any]:
+    dimension_values = dict(zip(dimensions, row.get("keys", [])))
+    payload: Dict[str, Any] = {
+        "property_url": site_url,
+        "period_start": period_start,
+        "period_end": period_end,
+        "rank": rank,
+        "requested_at": requested_at.isoformat(),
+        "clicks": row.get("clicks", 0.0),
+        "impressions": row.get("impressions", 0.0),
+        "ctr": row.get("ctr", 0.0),
+        "position": row.get("position", 0.0),
+    }
+    payload.update(dimension_values)
+    return payload
+
+
+def run() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+
+    properties_raw = os.getenv("GSC_PROPERTIES")
+    if not properties_raw:
+        raise RuntimeError("GSC_PROPERTIES environment variable is required")
+    properties = _parse_properties(properties_raw)
+
+    days = int(os.getenv("GSC_TOP_QUERIES_LOOKBACK", "7"))
+    end_date = _parse_date(os.getenv("GSC_TOP_QUERIES_END"), date.today())
+    start_date = (date.fromisoformat(end_date) - timedelta(days=days - 1)).isoformat()
+
+    dimensions_env = os.getenv("GSC_TOP_QUERIES_DIMENSIONS", "query")
+    dimensions = [item.strip() for item in dimensions_env.split(",") if item.strip()]
+    row_limit = int(os.getenv("GSC_TOP_QUERIES_LIMIT", "250"))
+
+    sort_metric = os.getenv("GSC_TOP_QUERIES_SORT", "clicks")
+    supabase_table = os.getenv("GSC_TOP_QUERIES_TABLE", "gsc_top_queries")
+    on_conflict = os.getenv(
+        "GSC_TOP_QUERIES_CONFLICT",
+        "property_url,period_start,period_end,rank",
+    )
+
+    authenticator = GSCAuthenticator()
+    supabase = SupabaseWriter()
+    requested_at = datetime.utcnow()
+
+    for site_url in properties:
+        rows = fetch_search_console_rows(
+            authenticator,
+            site_url=site_url,
+            start_date=start_date,
+            end_date=end_date,
+            dimensions=dimensions,
+            row_limit=row_limit,
+            dimension_filters=None,
+            search_type=os.getenv("GSC_SEARCH_TYPE", "web"),
+        )
+        rows.sort(key=lambda item: item.get(sort_metric, 0.0), reverse=True)
+        top_rows = rows[:row_limit]
+        payload = [
+            _build_payload(
+                site_url,
+                dimensions,
+                row,
+                period_start=start_date,
+                period_end=end_date,
+                requested_at=requested_at,
+                rank=index,
+            )
+            for index, row in enumerate(top_rows, start=1)
+        ]
+        if not payload:
+            logger.info("No top queries found for %s", site_url)
+            continue
+        supabase.upsert_rows(supabase_table, payload, on_conflict=on_conflict)
+
+
+def main() -> None:
+    try:
+        run()
+    except Exception:  # pragma: no cover
+        logger.exception("GSC top queries pipeline failed")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/monitors_sync.py
+++ b/monitors_sync.py
@@ -1,0 +1,90 @@
+"""Synchronise monitor definitions with Supabase."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from util_supabase import SupabaseWriter
+
+logger = logging.getLogger(__name__)
+
+
+def _load_definitions() -> List[Dict[str, Any]]:
+    file_path = os.getenv("MONITORS_FILE")
+    if file_path:
+        logger.info("Loading monitor definitions from %s", file_path)
+        path = Path(file_path)
+        content = path.read_text(encoding="utf-8")
+    else:
+        content = os.getenv("MONITORS_JSON")
+        if not content:
+            raise RuntimeError("Either MONITORS_FILE or MONITORS_JSON must be provided")
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Monitor definitions must be valid JSON") from exc
+    if isinstance(data, dict):
+        data = data.get("monitors") or []
+    if not isinstance(data, list):
+        raise RuntimeError("Monitor definitions must be a list")
+    return data
+
+
+def _normalise(definition: Dict[str, Any]) -> Dict[str, Any]:
+    keyword = definition.get("keyword")
+    if not keyword:
+        raise RuntimeError("Monitor definition missing keyword")
+
+    default_engine = os.getenv("MONITORS_DEFAULT_ENGINE", "google")
+    default_device = os.getenv("MONITORS_DEFAULT_DEVICE", "desktop")
+
+    payload: Dict[str, Any] = {
+        "keyword": keyword,
+        "target_url": definition.get("url") or definition.get("target_url"),
+        "engine": definition.get("engine") or default_engine,
+        "device": definition.get("device") or default_device,
+        "location": definition.get("location") or os.getenv("MONITORS_DEFAULT_LOCATION"),
+        "language": definition.get("language") or os.getenv("MONITORS_DEFAULT_LANGUAGE"),
+        "tags": definition.get("tags"),
+        "active": definition.get("active", True),
+        "metadata": definition.get("metadata"),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+
+    if isinstance(payload["tags"], (list, tuple)):
+        payload["tags"] = ",".join(str(tag) for tag in payload["tags"])
+
+    return payload
+
+
+def run() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+    supabase_table = os.getenv("MONITORS_TABLE", "monitor_keywords")
+    on_conflict = os.getenv(
+        "MONITORS_CONFLICT_COLUMNS",
+        "keyword,engine,device,location,language",
+    )
+
+    definitions = [_normalise(defn) for defn in _load_definitions()]
+    if not definitions:
+        logger.info("No monitor definitions supplied")
+        return
+
+    supabase = SupabaseWriter()
+    supabase.upsert_rows(supabase_table, definitions, on_conflict=on_conflict)
+
+
+def main() -> None:
+    try:
+        run()
+    except Exception:  # pragma: no cover
+        logger.exception("Monitor sync failed")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/ranks_pull.py
+++ b/ranks_pull.py
@@ -1,0 +1,152 @@
+"""Pull keyword ranks from the Check Position API and upsert them into Supabase."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Tuple
+
+from util_checkpos import CheckPositionClient
+from util_supabase import SupabaseWriter
+
+logger = logging.getLogger(__name__)
+
+
+def _group_monitors(monitors: Iterable[Dict[str, Any]]) -> Dict[Tuple[str, str, str, str, str], List[Dict[str, Any]]]:
+    grouped: Dict[Tuple[str, str, str, str, str], List[Dict[str, Any]]] = defaultdict(list)
+    default_engine = os.getenv("MONITORS_DEFAULT_ENGINE", "google")
+    default_device = os.getenv("MONITORS_DEFAULT_DEVICE", "desktop")
+    for monitor in monitors:
+        keyword = monitor.get("keyword")
+        if not keyword:
+            logger.debug("Skipping monitor without keyword: %s", monitor)
+            continue
+        engine = monitor.get("engine") or default_engine
+        device = monitor.get("device") or default_device
+        location = monitor.get("location") or os.getenv("MONITORS_DEFAULT_LOCATION")
+        language = monitor.get("language") or os.getenv("MONITORS_DEFAULT_LANGUAGE")
+        target_url = monitor.get("target_url") or monitor.get("url")
+        key = (engine, device, location or "", language or "", target_url or "")
+        grouped[key].append(monitor)
+    return grouped
+
+
+def _build_records(
+    monitors: Iterable[Dict[str, Any]],
+    responses: List[Dict[str, Any]],
+    *,
+    engine: str,
+    device: str,
+    location: str,
+    language: str,
+    target_url: str,
+    checked_at: datetime,
+) -> List[Dict[str, Any]]:
+    monitor_by_keyword = {str(m["keyword"]).lower(): m for m in monitors if m.get("keyword")}
+    records: List[Dict[str, Any]] = []
+
+    for item in responses:
+        keyword = str(item.get("keyword") or item.get("query") or "").strip()
+        if not keyword:
+            continue
+        monitor = monitor_by_keyword.get(keyword.lower())
+        if not monitor:
+            logger.debug("Received rank for unexpected keyword %s", keyword)
+            continue
+        record = {
+            "monitor_id": monitor.get("id"),
+            "keyword": monitor.get("keyword"),
+            "engine": engine,
+            "device": device,
+            "location": location or None,
+            "language": language or None,
+            "target_url": target_url or monitor.get("target_url"),
+            "rank": item.get("rank") or item.get("position"),
+            "url_found": item.get("url") or item.get("result_url"),
+            "checked_at": checked_at.isoformat(),
+            "raw_response": json.dumps(item),
+        }
+        records.append(record)
+    return records
+
+
+def run() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+
+    supabase = SupabaseWriter()
+    client = CheckPositionClient()
+
+    monitors_table = os.getenv("MONITORS_TABLE", "monitor_keywords")
+    monitor_filters = json.loads(os.getenv("RANKS_MONITOR_FILTERS", "{}"))
+    select = os.getenv(
+        "RANKS_MONITOR_SELECT",
+        "id,keyword,target_url,engine,device,location,language",
+    )
+    monitors = supabase.fetch_rows(monitors_table, select=select, filters=monitor_filters)
+    if not monitors:
+        logger.info("No monitors found, skipping rank pull")
+        return
+
+    grouped = _group_monitors(monitors)
+    ranks_table = os.getenv("RANKS_TABLE", "search_ranks")
+    on_conflict = os.getenv("RANKS_CONFLICT_COLUMNS", "monitor_id,checked_at")
+    checked_at = datetime.utcnow()
+
+    all_records: List[Dict[str, Any]] = []
+    for (engine, device, location, language, target_url), items in grouped.items():
+        keywords = [item["keyword"] for item in items if item.get("keyword")]
+        if not keywords:
+            continue
+        logger.info(
+            "Fetching ranks for %s keywords (engine=%s device=%s location=%s language=%s)",
+            len(keywords),
+            engine,
+            device,
+            location or "-",
+            language or "-",
+        )
+        responses = client.fetch_positions(
+            keywords,
+            engine=engine,
+            device=device,
+            location=location or None,
+            language=language or None,
+            url=target_url or None,
+            depth=int(os.getenv("RANKS_DEPTH", "50")),
+        )
+        records = _build_records(
+            items,
+            responses,
+            engine=engine,
+            device=device,
+            location=location,
+            language=language,
+            target_url=target_url,
+            checked_at=checked_at,
+        )
+        all_records.extend(records)
+
+    if not all_records:
+        logger.info("No rank records produced")
+        return
+
+    supabase.upsert_rows(
+        ranks_table,
+        all_records,
+        on_conflict=on_conflict,
+        chunk_size=int(os.getenv("RANKS_UPSERT_CHUNK", "200")),
+    )
+
+
+def main() -> None:
+    try:
+        run()
+    except Exception:  # pragma: no cover
+        logger.exception("Rank pull failed")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/util_checkpos.py
+++ b/util_checkpos.py
@@ -1,0 +1,136 @@
+"""Helper functions for interacting with the Check Position API."""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure(value: Optional[str], name: str) -> str:
+    if not value:
+        raise RuntimeError(f"Missing required configuration value: {name}")
+    return value
+
+
+class CheckPositionClient:
+    """Lightweight wrapper around the Check Position HTTP API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        max_retries: int = 4,
+        backoff_factor: float = 1.5,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.base_url = (base_url or os.getenv("CHECKPOS_API_URL") or "https://api.checkposition.com").rstrip("/")
+        self.api_key = _ensure(api_key or os.getenv("CHECKPOS_API_KEY"), "CHECKPOS_API_KEY")
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
+        self.session = session or requests.Session()
+
+    # ------------------------------------------------------------------
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Mapping[str, Any]] = None,
+        json_body: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                response = self.session.request(
+                    method,
+                    url,
+                    headers=headers,
+                    params=params,
+                    json=json_body,
+                    timeout=30,
+                )
+            except requests.RequestException as exc:
+                if attempt >= self.max_retries:
+                    raise
+                sleep_seconds = self.backoff_factor * (2 ** (attempt - 1))
+                logger.warning(
+                    "Check Position request to %s failed (attempt %s/%s): %s", url, attempt, self.max_retries, exc
+                )
+                time.sleep(sleep_seconds)
+                continue
+
+            if response.status_code >= 500 and attempt < self.max_retries:
+                sleep_seconds = self.backoff_factor * (2 ** (attempt - 1))
+                logger.info(
+                    "Check Position server error %s on %s (attempt %s/%s), retrying in %.1fs",
+                    response.status_code,
+                    url,
+                    attempt,
+                    self.max_retries,
+                    sleep_seconds,
+                )
+                time.sleep(sleep_seconds)
+                continue
+
+            if response.status_code >= 400:
+                raise RuntimeError(
+                    f"Check Position request failed with status {response.status_code}: {response.text}"
+                )
+
+            try:
+                return response.json()
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"Check Position returned invalid JSON for {url}: {response.text}"
+                ) from exc
+
+        # The loop either returns or raises, keep mypy happy.
+        raise RuntimeError("Failed to communicate with Check Position API")
+
+    # ------------------------------------------------------------------
+    def fetch_positions(
+        self,
+        keywords: Iterable[str],
+        *,
+        engine: str = "google",
+        device: str = "desktop",
+        location: Optional[str] = None,
+        language: Optional[str] = None,
+        url: Optional[str] = None,
+        depth: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """Fetch ranking information for a collection of ``keywords``."""
+
+        payload: Dict[str, Any] = {
+            "engine": engine,
+            "device": device,
+            "depth": depth,
+            "keywords": list(keywords),
+        }
+        if location:
+            payload["location"] = location
+        if language:
+            payload["language"] = language
+        if url:
+            payload["url"] = url
+
+        response = self._request("POST", "/v1/ranks", json_body=payload)
+        data = response.get("data") or response.get("results") or response
+        if isinstance(data, dict) and "data" in data:
+            data = data["data"]
+        if not isinstance(data, list):
+            raise RuntimeError(
+                "Unexpected Check Position response shape. Expected list under 'data' or 'results'."
+            )
+        return data
+
+
+__all__ = ["CheckPositionClient"]

--- a/util_gsc_oauth.py
+++ b/util_gsc_oauth.py
@@ -1,0 +1,202 @@
+"""Utilities for authenticating against the Google Search Console API.
+
+The module exposes a :class:`GSCAuthenticator` class that performs refresh token
+flows and automatically retries transient failures.  The implementation avoids
+external dependencies so the utilities can be embedded into light-weight data
+pipelines.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when the OAuth configuration is missing."""
+
+
+@dataclass
+class _TokenCache:
+    """Simple in-memory representation of an access token."""
+
+    access_token: str
+    expires_at: float
+
+    def is_valid(self) -> bool:
+        return bool(self.access_token) and time.time() < self.expires_at - 30
+
+
+class GSCAuthenticator:
+    """Small helper responsible for refreshing OAuth access tokens.
+
+    Parameters
+    ----------
+    client_id:
+        Google OAuth client identifier.  If omitted the value is looked up in
+        the ``GSC_CLIENT_ID`` environment variable.
+    client_secret:
+        Google OAuth client secret or service account secret.  Defaults to the
+        ``GSC_CLIENT_SECRET`` environment variable.
+    refresh_token:
+        Refresh token used to mint short lived access tokens.  Defaults to the
+        ``GSC_REFRESH_TOKEN`` environment variable.
+    token_endpoint:
+        Override for the OAuth token endpoint.  This is primarily useful when
+        stubbing requests in tests.
+    max_retries / backoff_factor:
+        Controls the exponential backoff strategy used when talking to the
+        OAuth endpoint.
+    session:
+        Optional :class:`requests.Session` instance.  Supplying a pre-configured
+        session makes it easy to provide additional retry logic or request
+        hooks.
+    """
+
+    def __init__(
+        self,
+        *,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        refresh_token: Optional[str] = None,
+        token_endpoint: str = DEFAULT_TOKEN_ENDPOINT,
+        max_retries: int = 5,
+        backoff_factor: float = 1.5,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.client_id = client_id or os.getenv("GSC_CLIENT_ID")
+        self.client_secret = client_secret or os.getenv("GSC_CLIENT_SECRET")
+        self.refresh_token = refresh_token or os.getenv("GSC_REFRESH_TOKEN")
+        self.token_endpoint = token_endpoint
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
+        self.session = session or requests.Session()
+
+        if not all([self.client_id, self.client_secret, self.refresh_token]):
+            raise ConfigurationError(
+                "GSC OAuth configuration is incomplete. Ensure GSC_CLIENT_ID, "
+                "GSC_CLIENT_SECRET and GSC_REFRESH_TOKEN are provided."
+            )
+
+        self._token: Optional[_TokenCache] = None
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    def _refresh_access_token(self) -> _TokenCache:
+        payload = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "refresh_token": self.refresh_token,
+            "grant_type": "refresh_token",
+        }
+
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                response = self.session.post(self.token_endpoint, data=payload, timeout=30)
+                if response.status_code >= 500:
+                    raise RuntimeError(
+                        f"OAuth token endpoint returned {response.status_code}: {response.text}"
+                    )
+                response.raise_for_status()
+                data = response.json()
+            except (requests.RequestException, ValueError) as exc:  # ValueError from json()
+                logger.warning(
+                    "Failed to refresh Google Search Console token (attempt %s/%s): %s",
+                    attempt,
+                    self.max_retries,
+                    exc,
+                )
+                if attempt >= self.max_retries:
+                    raise
+                sleep_seconds = self.backoff_factor * (2 ** (attempt - 1))
+                time.sleep(sleep_seconds)
+                continue
+
+            access_token = data.get("access_token")
+            expires_in = int(data.get("expires_in", 3600))
+            if not access_token:
+                raise RuntimeError(
+                    "Google OAuth token response did not contain an access_token. "
+                    f"Payload: {json.dumps(data)}"
+                )
+
+            logger.debug("Obtained new GSC access token valid for %s seconds", expires_in)
+            return _TokenCache(access_token=access_token, expires_at=time.time() + expires_in)
+
+        # Should never reach this line due to the raise inside the loop.
+        raise RuntimeError("Unable to refresh Google Search Console access token")
+
+    # ------------------------------------------------------------------
+    def get_access_token(self, *, force_refresh: bool = False) -> str:
+        """Return a valid access token, refreshing it when necessary."""
+
+        with self._lock:
+            if not force_refresh and self._token and self._token.is_valid():
+                return self._token.access_token
+
+            self._token = self._refresh_access_token()
+            return self._token.access_token
+
+    # ------------------------------------------------------------------
+    def authenticated_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        retry_on_unauthorized: bool = True,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Perform an authenticated HTTP request against the Search Console API.
+
+        The helper attaches the ``Authorization`` header, refreshes the token
+        whenever the call returns ``401`` and retries the request automatically.
+        """
+
+        attempt = 0
+        headers = dict(headers or {})
+
+        while True:
+            attempt += 1
+            token = self.get_access_token(force_refresh=attempt > 1)
+            headers["Authorization"] = f"Bearer {token}"
+            try:
+                response = self.session.request(method, url, headers=headers, timeout=30, **kwargs)
+            except requests.RequestException:
+                if attempt > self.max_retries:
+                    raise
+                sleep_seconds = self.backoff_factor * (2 ** (attempt - 1))
+                logger.debug("Retrying request after transport failure in %ss", sleep_seconds)
+                time.sleep(sleep_seconds)
+                continue
+
+            if retry_on_unauthorized and response.status_code == 401 and attempt <= self.max_retries:
+                logger.info("GSC request unauthorized, refreshing token and retrying")
+                self.get_access_token(force_refresh=True)
+                continue
+
+            if response.status_code >= 500 and attempt <= self.max_retries:
+                sleep_seconds = self.backoff_factor * (2 ** (attempt - 1))
+                logger.warning(
+                    "GSC request returned %s, retrying in %.1fs",
+                    response.status_code,
+                    sleep_seconds,
+                )
+                time.sleep(sleep_seconds)
+                continue
+
+            return response
+
+
+__all__ = ["GSCAuthenticator", "ConfigurationError"]

--- a/util_supabase.py
+++ b/util_supabase.py
@@ -1,0 +1,186 @@
+"""Helpers for interacting with Supabase's REST endpoint.
+
+The Supabase Python SDK adds a hefty dependency footprint; these utilities
+implement the small portion that the data pipelines need: upserting batches of
+rows and reading configuration from environment variables.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseConfigurationError(RuntimeError):
+    """Raised when the Supabase configuration is missing."""
+
+
+def _chunked(iterable: Iterable[Mapping[str, Any]], chunk_size: int) -> Iterable[List[Mapping[str, Any]]]:
+    chunk: List[Mapping[str, Any]] = []
+    for item in iterable:
+        chunk.append(item)
+        if len(chunk) >= chunk_size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+class SupabaseWriter:
+    """Thin REST client aware of Supabase specific headers and retry logic."""
+
+    def __init__(
+        self,
+        *,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        max_retries: int = 4,
+        backoff_factor: float = 1.5,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.url = (url or os.getenv("SUPABASE_URL"))
+        self.api_key = api_key or os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_ANON_KEY")
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
+        self.session = session or requests.Session()
+
+        if not self.url or not self.api_key:
+            raise SupabaseConfigurationError(
+                "Supabase configuration missing. Provide SUPABASE_URL and either "
+                "SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY."
+            )
+
+    # ------------------------------------------------------------------
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        headers: Optional[MutableMapping[str, str]] = None,
+        params: Optional[Mapping[str, Any]] = None,
+        json_body: Optional[Any] = None,
+    ) -> requests.Response:
+        url = f"{self.url.rstrip('/')}/rest/v1/{path.lstrip('/')}"
+        headers = headers or {}
+        headers.setdefault("apikey", self.api_key)
+        headers.setdefault("Authorization", f"Bearer {self.api_key}")
+
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                response = self.session.request(
+                    method,
+                    url,
+                    headers=headers,
+                    params=params,
+                    json=json_body,
+                    timeout=30,
+                )
+            except requests.RequestException as exc:
+                if attempt >= self.max_retries:
+                    raise
+                sleep_seconds = self.backoff_factor * (2 ** (attempt - 1))
+                logger.warning(
+                    "Supabase request to %s failed (attempt %s/%s): %s", url, attempt, self.max_retries, exc
+                )
+                time.sleep(sleep_seconds)
+                continue
+
+            if response.status_code >= 500 and attempt < self.max_retries:
+                sleep_seconds = self.backoff_factor * (2 ** (attempt - 1))
+                logger.info(
+                    "Supabase server error %s on %s (attempt %s/%s), retrying in %.1fs", 
+                    response.status_code,
+                    url,
+                    attempt,
+                    self.max_retries,
+                    sleep_seconds,
+                )
+                time.sleep(sleep_seconds)
+                continue
+
+            return response
+
+        return response  # pragma: no cover - loop always returns earlier or raises
+
+    # ------------------------------------------------------------------
+    def upsert_rows(
+        self,
+        table: str,
+        rows: Iterable[Mapping[str, Any]],
+        *,
+        on_conflict: Optional[str] = None,
+        chunk_size: int = 500,
+        ignore_duplicates: bool = False,
+    ) -> None:
+        """Upsert ``rows`` into ``table`` using Supabase's REST endpoint."""
+
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        prefer_directives = ["resolution=merge-duplicates"]
+        if ignore_duplicates:
+            prefer_directives.append("ignore-duplicates")
+        headers["Prefer"] = ",".join(prefer_directives)
+
+        params: Dict[str, Any] = {}
+        if on_conflict:
+            params["on_conflict"] = on_conflict
+
+        for chunk in _chunked(rows, chunk_size):
+            payload = [dict(item) for item in chunk]
+            response = self._request(
+                "POST",
+                table,
+                headers=headers,
+                params=params,
+                json_body=payload,
+            )
+            if response.status_code not in {200, 201, 204}:
+                raise RuntimeError(
+                    f"Supabase upsert failed with status {response.status_code}: {response.text}"
+                )
+            logger.info("Upserted %s rows into %s", len(payload), table)
+
+    # ------------------------------------------------------------------
+    def fetch_rows(
+        self,
+        table: str,
+        *,
+        select: str = "*",
+        filters: Optional[Mapping[str, str]] = None,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        params: Dict[str, Any] = {"select": select}
+        if filters:
+            params.update(filters)
+        if limit is not None:
+            params["limit"] = str(limit)
+
+        response = self._request("GET", table, params=params)
+        if response.status_code not in {200, 206}:
+            raise RuntimeError(
+                f"Supabase fetch failed with status {response.status_code}: {response.text}"
+            )
+        if not response.text:
+            return []
+        try:
+            data = response.json()
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Supabase returned invalid JSON for table {table}: {response.text}"
+            ) from exc
+        if not isinstance(data, list):
+            raise RuntimeError(
+                f"Expected Supabase to return a list, received: {type(data).__name__}"
+            )
+        return data
+
+
+__all__ = ["SupabaseWriter", "SupabaseConfigurationError"]


### PR DESCRIPTION
## Summary
- add OAuth helper for Google Search Console and Supabase/Check Position utility clients
- implement Search Console ingestion pipelines for performance rows and top queries
- add monitor synchronisation and Check Position rank collection scripts with robust logging

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68da5f1daf8083318eaf7df509e3a699