### PR TITLE
Add scheduled SEO automation workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
 # seo-dashboard
-Première initialisation du repo.
+
+This repository contains automation scripts and GitHub Actions workflows that orchestrate
+SEO data synchronisation tasks.
+
+## Workflows
+
+Reusable automation lives under [`workflows/`](workflows/) and is deployed through four
+scheduled GitHub Actions workflows:
+
+| Workflow | Schedule (UTC) | Purpose |
+| --- | --- | --- |
+| `gsc_pull.yml` | Daily at 02:30 | Pull Google Search Console data for configured properties. |
+| `monitors_sync.yml` | Weekdays at 06:00 | Synchronise monitor definitions from the monitoring provider. |
+| `ranks_pull.yml` | Daily at 03:15 | Fetch rank-tracking data for the configured project. |
+| `refresh_views.yml` | Daily at 05:00 | Refresh database or Supabase views so dashboards stay current. |
+
+Each workflow sets up Python 3.11, installs dependencies from `requirements.txt` when it is
+present, and invokes the companion script in [`scripts/`](scripts/) with retry logic so
+transient failures do not abort the run immediately.
+
+## Required GitHub secrets
+
+| Secret | Used by | Description |
+| --- | --- | --- |
+| `GSC_SERVICE_ACCOUNT_JSON` | `gsc_pull.yml` | JSON blob for the Google service account authorised for Search Console. |
+| `GSC_PROPERTY_IDS` | `gsc_pull.yml` | Comma-separated list of Search Console property identifiers to pull. |
+| `MONITORS_API_TOKEN` | `monitors_sync.yml` | API token that grants access to the monitoring service. |
+| `MONITORS_BASE_URL` | `monitors_sync.yml` | Base URL of the monitoring service API. |
+| `RANKS_API_TOKEN` | `ranks_pull.yml` | Credential used to authenticate against the rank-tracking API. |
+| `RANKS_PROJECT_ID` | `ranks_pull.yml` | Identifier for the project whose ranking data is fetched. |
+| `SUPABASE_URL` | `refresh_views.yml` | Supabase project URL hosting the database views. |
+| `SUPABASE_SERVICE_ROLE_KEY` | `refresh_views.yml` | Service role key permitted to refresh views. |
+
+Secrets must be configured in the repository or organisation settings before the workflows
+can run on GitHub.
+
+## Local verification
+
+The workflows can be exercised locally with [`act`](https://github.com/nektos/act). Examples:
+
+```bash
+act workflow_dispatch -W workflows/gsc_pull.yml
+act workflow_dispatch -W workflows/monitors_sync.yml -j run
+```
+
+When `act` is unavailable, run the scripts directly with the required environment variables
+set. This repository includes lightweight placeholder implementations that validate required
+configuration and log their progress:
+
+```bash
+export GSC_SERVICE_ACCOUNT_JSON='{}'
+export GSC_PROPERTY_IDS='sc-domain:example.com'
+python scripts/gsc_pull.py
+```
+
+Replace the environment variable values with real credentials during production execution.

--- a/scripts/gsc_pull.py
+++ b/scripts/gsc_pull.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Entrypoint for pulling Google Search Console data."""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+REQUIRED_ENV_VARS = [
+    "GSC_SERVICE_ACCOUNT_JSON",
+    "GSC_PROPERTY_IDS",
+]
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def _validate_env() -> None:
+    missing = [name for name in REQUIRED_ENV_VARS if not os.getenv(name)]
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(sorted(missing))
+        )
+
+
+def main() -> None:
+    _configure_logging()
+    logging.info("Starting Google Search Console pull run")
+    _validate_env()
+
+    logging.info("Using properties: %s", os.environ.get("GSC_PROPERTY_IDS"))
+
+    # NOTE: Replace the placeholder logic below with the actual pull implementation.
+    logging.info("Performing placeholder GSC pull work")
+
+    logging.info(
+        "GSC pull completed successfully at %s",
+        datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001 - we want to log and exit cleanly
+        logging.getLogger(__name__).exception("GSC pull failed: %s", exc)
+        raise

--- a/scripts/monitors_sync.py
+++ b/scripts/monitors_sync.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Synchronise monitor definitions from an external service."""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+REQUIRED_ENV_VARS = [
+    "MONITORS_API_TOKEN",
+    "MONITORS_BASE_URL",
+]
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def _validate_env() -> None:
+    missing = [name for name in REQUIRED_ENV_VARS if not os.getenv(name)]
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(sorted(missing))
+        )
+
+
+def main() -> None:
+    _configure_logging()
+    logging.info("Starting monitors synchronisation run")
+    _validate_env()
+
+    logging.info(
+        "Syncing monitors from %s", os.environ.get("MONITORS_BASE_URL", "<undefined>")
+    )
+
+    # NOTE: Replace the placeholder logic below with the actual sync implementation.
+    logging.info("Performing placeholder monitors sync work")
+
+    logging.info(
+        "Monitors sync completed successfully at %s",
+        datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001 - we want to log and exit cleanly
+        logging.getLogger(__name__).exception("Monitors sync failed: %s", exc)
+        raise

--- a/scripts/ranks_pull.py
+++ b/scripts/ranks_pull.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Entrypoint for pulling rank tracking data."""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+REQUIRED_ENV_VARS = [
+    "RANKS_API_TOKEN",
+    "RANKS_PROJECT_ID",
+]
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def _validate_env() -> None:
+    missing = [name for name in REQUIRED_ENV_VARS if not os.getenv(name)]
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(sorted(missing))
+        )
+
+
+def main() -> None:
+    _configure_logging()
+    logging.info("Starting ranks pull run")
+    _validate_env()
+
+    logging.info(
+        "Requesting ranks for project %s", os.environ.get("RANKS_PROJECT_ID")
+    )
+
+    # NOTE: Replace the placeholder logic below with the actual pull implementation.
+    logging.info("Performing placeholder ranks pull work")
+
+    logging.info(
+        "Ranks pull completed successfully at %s",
+        datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001 - we want to log and exit cleanly
+        logging.getLogger(__name__).exception("Ranks pull failed: %s", exc)
+        raise

--- a/scripts/refresh_views.py
+++ b/scripts/refresh_views.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Refresh database views or materialized resources."""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+REQUIRED_ENV_VARS = [
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+]
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def _validate_env() -> None:
+    missing = [name for name in REQUIRED_ENV_VARS if not os.getenv(name)]
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(sorted(missing))
+        )
+
+
+def main() -> None:
+    _configure_logging()
+    logging.info("Starting refresh views run")
+    _validate_env()
+
+    logging.info(
+        "Refreshing Supabase views at %s", os.environ.get("SUPABASE_URL", "<undefined>")
+    )
+
+    # NOTE: Replace the placeholder logic below with the actual refresh implementation.
+    logging.info("Performing placeholder refresh views work")
+
+    logging.info(
+        "Refresh views completed successfully at %s",
+        datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001 - we want to log and exit cleanly
+        logging.getLogger(__name__).exception("Refresh views failed: %s", exc)
+        raise

--- a/workflows/gsc_pull.yml
+++ b/workflows/gsc_pull.yml
@@ -1,0 +1,58 @@
+name: GSC Pull
+
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+    inputs:
+      log_level:
+        description: "Optional log level override"
+        required: false
+        default: "info"
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: Pull Google Search Console data
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GSC_SERVICE_ACCOUNT_JSON: ${{ secrets.GSC_SERVICE_ACCOUNT_JSON }}
+      GSC_PROPERTY_IDS: ${{ secrets.GSC_PROPERTY_IDS }}
+      LOG_LEVEL: ${{ github.event.inputs.log_level || 'info' }}
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+
+      - name: Run GSC pull script with retries
+        run: |
+          set -euo pipefail
+          max_attempts=3
+          attempt=1
+          until python scripts/gsc_pull.py; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "GSC pull failed after $attempt attempts" >&2
+              exit 1
+            fi
+            echo "Attempt $attempt failed, retrying in 30 seconds..."
+            attempt=$((attempt + 1))
+            sleep 30
+          done

--- a/workflows/monitors_sync.yml
+++ b/workflows/monitors_sync.yml
@@ -1,0 +1,58 @@
+name: Monitors Sync
+
+on:
+  schedule:
+    - cron: "0 6 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run the sync without mutating remote resources"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: Sync monitoring configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      MONITORS_API_TOKEN: ${{ secrets.MONITORS_API_TOKEN }}
+      MONITORS_BASE_URL: ${{ secrets.MONITORS_BASE_URL }}
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+
+      - name: Run monitors sync with retries
+        run: |
+          set -euo pipefail
+          max_attempts=3
+          attempt=1
+          until python scripts/monitors_sync.py; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "Monitors sync failed after $attempt attempts" >&2
+              exit 1
+            fi
+            echo "Attempt $attempt failed, retrying in 30 seconds..."
+            attempt=$((attempt + 1))
+            sleep 30
+          done

--- a/workflows/ranks_pull.yml
+++ b/workflows/ranks_pull.yml
@@ -1,0 +1,58 @@
+name: Ranks Pull
+
+on:
+  schedule:
+    - cron: "15 3 * * *"
+  workflow_dispatch:
+    inputs:
+      country_code:
+        description: "Optional country override"
+        required: false
+        default: "US"
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: Pull ranking data
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RANKS_API_TOKEN: ${{ secrets.RANKS_API_TOKEN }}
+      RANKS_PROJECT_ID: ${{ secrets.RANKS_PROJECT_ID }}
+      COUNTRY_CODE: ${{ github.event.inputs.country_code || 'US' }}
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+
+      - name: Run ranks pull with retries
+        run: |
+          set -euo pipefail
+          max_attempts=3
+          attempt=1
+          until python scripts/ranks_pull.py; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "Ranks pull failed after $attempt attempts" >&2
+              exit 1
+            fi
+            echo "Attempt $attempt failed, retrying in 30 seconds..."
+            attempt=$((attempt + 1))
+            sleep 30
+          done

--- a/workflows/refresh_views.yml
+++ b/workflows/refresh_views.yml
@@ -1,0 +1,58 @@
+name: Refresh Views
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Optional list of views to refresh"
+        required: false
+        default: "all"
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: Refresh database views
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      TARGET: ${{ github.event.inputs.target || 'all' }}
+      PYTHONUNBUFFERED: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+
+      - name: Run refresh views with retries
+        run: |
+          set -euo pipefail
+          max_attempts=3
+          attempt=1
+          until python scripts/refresh_views.py; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "Refresh views failed after $attempt attempts" >&2
+              exit 1
+            fi
+            echo "Attempt $attempt failed, retrying in 30 seconds..."
+            attempt=$((attempt + 1))
+            sleep 30
+          done


### PR DESCRIPTION
## Summary
- add scheduled GitHub Actions workflows for Google Search Console, monitor sync, rank pulls, and refreshing views with retries
- introduce placeholder Python scripts that validate required secrets for each workflow
- document the necessary secrets and local verification steps in the README

## Testing
- python scripts/gsc_pull.py
- python scripts/monitors_sync.py
- python scripts/ranks_pull.py
- python scripts/refresh_views.py

------
https://chatgpt.com/codex/tasks/task_e_68da5f1bd51c833187f0ac609b69821d